### PR TITLE
Multiline support

### DIFF
--- a/tbump/file_bumper.py
+++ b/tbump/file_bumper.py
@@ -259,9 +259,9 @@ class FileBumper:
                 expanded_src = file_path.relative_to(self.working_path)
                 old_lines = file_path.read_text()
                 match = re.findall(search, old_lines, re.DOTALL | re.MULTILINE)
-                if len(match) > 0:
-                    replacement = search.replace(old_string, new_string)
-                    new_lines = re.sub(search,  replacement, old_lines, re.DOTALL | re.MULTILINE)
+                for m in match:
+                    replacement = m.replace(old_string, new_string)
+                    new_lines = old_lines.replace(m, replacement)
                     # we're using a dedicated multi-line patch class for this case
                     patch = MultilinePatch(
                                 self.working_path, str(expanded_src), new_lines, match, replacement

--- a/tbump/file_bumper.py
+++ b/tbump/file_bumper.py
@@ -22,8 +22,12 @@ class ChangeRequest:
 
 class MultilinePatch(tbump.action.Action):
     def __init__(
-            self, working_path: Path, src: str, new_lines: str, matches:
-            List[str], new_phrase: str
+        self,
+        working_path: Path,
+        src: str,
+        new_lines: str,
+        matches: List[str],
+        new_phrase: str,
     ):
         super().__init__()
         self.working_path = working_path
@@ -34,17 +38,18 @@ class MultilinePatch(tbump.action.Action):
 
     def print_self(self) -> None:
         for match in self.matches:
+            removed_lines = "\n".join([f"- {m}" for m in match.strip().split("\n")])
+            added_lines = "\n".join(
+                [f"+ {m}" for m in self.new_phrase.strip().split("\n")]
+            )
             # fmt: off
+            ui.info(ui.bold, self.src, ui.reset)
             ui.info(
-                ui.red, "- ", ui.reset,
-                ui.bold, self.src,  ui.reset,
-                " ", ui.red, re.escape(match.strip()),
+                ui.red, removed_lines, ui.reset,
                 sep="",
             )
             ui.info(
-                ui.green, "+ ", ui.reset,
-                ui.bold, self.src, ui.reset,
-                " ", ui.green, re.escape(self.new_phrase.strip()),
+                ui.green, added_lines, ui.reset,
                 sep="",
             )
             # fmt: on
@@ -71,18 +76,15 @@ class Patch(tbump.action.Action):
 
     def print_self(self) -> None:
         # fmt: off
+        ui.info(ui.bold, self.src, ui.reset, ":", self.lineno + 1, ui.reset,sep="")
         ui.info(
             ui.red, "- ", ui.reset,
-            ui.bold, self.src, ":", ui.reset,
-            ui.darkgray, self.lineno + 1, ui.reset,
-            " ", ui.red, self.old_line.strip(),
+            ui.red, self.old_line.strip(),
             sep="",
         )
         ui.info(
             ui.green, "+ ", ui.reset,
-            ui.bold, self.src, ":", ui.reset,
-            ui.darkgray, self.lineno + 1, ui.reset,
-            " ", ui.green, self.new_line.strip(),
+            ui.green, self.new_line.strip(),
             sep="",
         )
         # fmt: on
@@ -115,7 +117,7 @@ class BadSubstitution(tbump.Error):
         verb: str,
         groups: Dict[str, str],
         template: str,
-        version: str
+        version: str,
     ):
         super().__init__()
         self.src = src
@@ -264,8 +266,12 @@ class FileBumper:
                     new_lines = old_lines.replace(m, replacement)
                     # we're using a dedicated multi-line patch class for this case
                     patch = MultilinePatch(
-                                self.working_path, str(expanded_src), new_lines, match, replacement
-                            )
+                        self.working_path,
+                        str(expanded_src),
+                        new_lines,
+                        match,
+                        replacement,
+                    )
                     patches.append(patch)
 
         else:

--- a/tbump/test/data/Cargo.toml
+++ b/tbump/test/data/Cargo.toml
@@ -1,0 +1,11 @@
+[[package]]
+name = "my-project"
+version = "1.2.41-alpha-1"
+
+[[package]]
+name = "rustc-hash"
+version = "1.2.41-alpha-1"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.41-alpha-1"

--- a/tbump/test/data/tbump.toml
+++ b/tbump/test/data/tbump.toml
@@ -23,6 +23,10 @@ src = "package.json"
 search = '"version": "{current_version}"'
 
 [[file]]
+src = "Cargo.toml"
+search = 'name = "my-project"\nversion = "{current_version}"'
+
+[[file]]
 src = "VERSION"
 
 [[file]]

--- a/tbump/test/test_config.py
+++ b/tbump/test/test_config.py
@@ -19,6 +19,10 @@ def test_happy_parse(test_data_path: Path) -> None:
     )
     version_txt = tbump.config.File(src="VERSION")
     pub_js = tbump.config.File(src="pub.js", version_template="{major}.{minor}.{patch}")
+    cargo_toml = tbump.config.File(
+        src="Cargo.toml",
+        search='name = "my-project"\\nversion = "{current_version}"',
+    )
     glob = tbump.config.File(
         src="glob*.?", search='version_[a-z]+ = "{current_version}"'
     )
@@ -38,7 +42,7 @@ def test_happy_parse(test_data_path: Path) -> None:
 
     assert config.version_regex.pattern == expected_pattern
 
-    assert config.files == [foo_json, version_txt, pub_js, glob]
+    assert config.files == [foo_json, cargo_toml, version_txt, pub_js, glob]
 
     assert config.current_version == "1.2.41-alpha-1"
 

--- a/tbump/test/test_file_bumper.py
+++ b/tbump/test/test_file_bumper.py
@@ -21,6 +21,10 @@ def test_file_bumper_simple(test_repo: Path) -> None:
     assert file_contains(test_repo / "glob-one.c", 'version_one = "1.2.41-alpha-2"')
     assert file_contains(test_repo / "glob-two.v", 'version_two = "1.2.41-alpha-2"')
 
+    # one occurence is bumped up, others remain unchanged
+    assert file_contains(test_repo / "Cargo.toml", 'version = "1.2.41-alpha-2"')
+    assert file_contains(test_repo / "Cargo.toml", 'version = "1.2.41-alpha-1"')
+
 
 def test_patcher_preserve_endings(tmp_path: Path) -> None:
     foo_txt = tmp_path / "foo.txt"


### PR DESCRIPTION
## About
This is a PR covering feature idea from #83.

I've noticed some work started on `dm/multiline` branch, but I wasn't sure what the status of that was, (looked stalled to me).
Using a bit of spare time, here is my proposed extension to support the feature.

Implementation is based on the idea that when line-ending characters are detected in search phrase, then separate `MultilinePatch` class handles the file patching. For that, a Python's builtin `re` regex utils with `re.MULTILINE` flag are used.
The code for per-line search & replace like existed till now, is left unaffected, as I've been extending the code, rather modifying it.

All tests pass. The features used in extra test cases do correspond to what has been proposed in #83 description.

## Implications

Since the patching for such case is file-based and not line-based (like the rest of the code), the UI information about the diff does not display numbers.
