### PR TITLE
Abtract away config file

### DIFF
--- a/tbump/cli.py
+++ b/tbump/cli.py
@@ -215,8 +215,8 @@ def bump(options: BumpOptions, operations: List[str]) -> None:
         else:
             raise
 
-    file_bumper = FileBumper(working_path)
-    file_bumper.set_config_file(config_file)
+    file_bumper = FileBumper(working_path, config)
+    file_bumper.check_files_exist()
 
     executor = Executor(new_version, file_bumper, config_file.updater)
 

--- a/tbump/cli.py
+++ b/tbump/cli.py
@@ -218,7 +218,7 @@ def bump(options: BumpOptions, operations: List[str]) -> None:
     file_bumper = FileBumper(working_path)
     file_bumper.set_config_file(config_file)
 
-    executor = Executor(new_version, file_bumper)
+    executor = Executor(new_version, file_bumper, config_file.updater)
 
     hooks_runner = HooksRunner(working_path, config.current_version, operations)
     if "hooks" in operations:

--- a/tbump/config.py
+++ b/tbump/config.py
@@ -2,7 +2,7 @@ import abc
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Pattern, Tuple, Union
+from typing import Callable, Dict, List, Optional, Pattern, Tuple, Union
 
 import cli_ui as ui
 import schema
@@ -41,6 +41,12 @@ class Config:
     github_url: Optional[str]
 
 
+@dataclass
+class ConfigFileVersionUpdater:
+    update_version: Callable[[str], None]
+    file_name: str
+
+
 class ConfigFile(metaclass=abc.ABCMeta):
     """Base class representing a config file"""
 
@@ -69,6 +75,10 @@ class ConfigFile(metaclass=abc.ABCMeta):
         res = from_parsed_config(parsed)
         validate_config(res)
         return res
+
+    @property
+    def updater(self) -> ConfigFileVersionUpdater:
+        return ConfigFileVersionUpdater(self.set_new_version, self.path.name)
 
 
 class TbumpTomlConfig(ConfigFile):

--- a/tbump/executor.py
+++ b/tbump/executor.py
@@ -3,7 +3,7 @@ from typing import List, Sequence
 import cli_ui as ui
 
 from tbump.action import Action
-from tbump.config import ConfigFile
+from tbump.config import ConfigFileVersionUpdater
 from tbump.file_bumper import FileBumper
 from tbump.git_bumper import GitBumper
 from tbump.hooks import HooksRunner
@@ -41,8 +41,8 @@ class ActionGroup:
 
 
 class UpdateConfig(Action):
-    def __init__(self, config_file: ConfigFile, new_version: str):
-        self.config_file = config_file
+    def __init__(self, updater: ConfigFileVersionUpdater, new_version: str):
+        self.updater = updater
         self.new_version = new_version
 
     def print_self(self) -> None:
@@ -52,23 +52,26 @@ class UpdateConfig(Action):
         # fmt: off
         ui.info_3(
             "Set current version to", ui.blue, self.new_version, ui.reset,
-            "in", ui.bold, self.config_file.path.name
+            "in", ui.bold, self.updater.file_name
         )
         # fmt: on
-        self.config_file.set_new_version(self.new_version)
+        self.updater.update_version(self.new_version)
 
 
 class Executor:
-    def __init__(self, new_version: str, file_bumper: FileBumper):
+    def __init__(
+        self,
+        new_version: str,
+        file_bumper: FileBumper,
+        config_version_updater: ConfigFileVersionUpdater,
+    ):
         self.new_version = new_version
         self.work: List[ActionGroup] = []
 
-        config_file = file_bumper.config_file
-        assert config_file
-        update_config = UpdateConfig(config_file, new_version)
+        update_config = UpdateConfig(config_version_updater, new_version)
 
         update_config_group = ActionGroup(
-            f"Would update current version in {config_file.path.name}",
+            f"Would update current version in {config_version_updater.file_name}",
             "Updating current version",
             [update_config],
             should_enumerate=False,


### PR DESCRIPTION
This change reduces the number of classes that directory know about `ConfigFile`. This is another small step towards #143. The end goal is to have these classes work off a `Config` like dataclass that is distinct from the config file format and is the result of merging the settings specified in the config file and any given command line arguments. The data structures being introduced might not survive the whole process. But I find it easier these seams in smalls steps that can be cleaned up afterward if necessary.