### PR TITLE
test: fix bad example project

### DIFF
--- a/tbump/test/pyproject/pyproject.toml
+++ b/tbump/test/pyproject/pyproject.toml
@@ -30,9 +30,5 @@ message_template = "Bump to {new_version}"
 tag_template = "v{new_version}"
 
 [[tool.tbump.file]]
-src = "pyproject.toml"
-search = 'version = "{current_version}"'
-
-[[tool.tbump.file]]
 src = "foo/__init__.py"
 search = '__version__ = "{current_version}"'


### PR DESCRIPTION
In real life, people won't explicitly put pyproject.toml in the list of files to bump !