### PR TITLE
add context to error

### DIFF
--- a/tbump/file_bumper.py
+++ b/tbump/file_bumper.py
@@ -112,7 +112,7 @@ class SourceFileNotFound(Error):
         self.src = src
 
     def print_error(self) -> None:
-        ui.error(self.src, "does not exist")
+        ui.error("the file", self.src, "does not exist")
 
 
 class CurrentVersionNotFound(Error):


### PR DESCRIPTION
I generated a tbump.toml file using `tbump init` and i did not edit the file.src configuration string and subsequently got this error 

![image](https://github.com/your-tools/tbump/assets/45801817/5aea9f28-326f-42db-b43d-11fcb426ffa1)

which did not really helped because it took some time to figure out he the `...` was the file.src config string. So i changed the error message to  make that easy to understand