### PR TITLE
 tbump should be able to make signed tag #133 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 .mypy_cache/
 
 .vscode
+.idea

--- a/tbump.toml
+++ b/tbump.toml
@@ -13,7 +13,7 @@ regex = '''
 
 
 [git]
-message_template  = "Bump to {new_version}"
+message_template = "Bump to {new_version}"
 tag_template = "v{new_version}"
 
 

--- a/tbump/config.py
+++ b/tbump/config.py
@@ -35,6 +35,7 @@ class Config:
     git_tag_template: str
     git_message_template: str
     atomic_push: bool
+    sign: bool
 
     files: List[File]
     hooks: List[Hook]
@@ -201,6 +202,7 @@ def validate_basic_schema(config: dict) -> None:
                 "message_template": str,
                 "tag_template": str,
                 schema.Optional("atomic_push"): bool,
+                schema.Optional("sign"): bool,
             },
             "file": [file_schema],
             schema.Optional("field"): [field_schema],
@@ -296,6 +298,7 @@ def from_parsed_config(parsed: dict) -> Config:
     git_message_template = parsed["git"]["message_template"]
     git_tag_template = parsed["git"]["tag_template"]
     atomic_push = parsed["git"].get("atomic_push", True)
+    sign = parsed["git"].get("sign", False)
     version_regex = re.compile(parsed["version"]["regex"], re.VERBOSE)
     files = []
     for file_dict in parsed["file"]:
@@ -328,6 +331,7 @@ def from_parsed_config(parsed: dict) -> Config:
         git_message_template=git_message_template,
         git_tag_template=git_tag_template,
         atomic_push=atomic_push,
+        sign=sign,
         fields=fields,
         files=files,
         hooks=hooks,

--- a/tbump/git_bumper.py
+++ b/tbump/git_bumper.py
@@ -170,7 +170,13 @@ class GitBumper:
                 )
             else:
                 self.add_command(
-                    res, "tag", "--sign", "--annotate", "--message", tag_message, tag_name
+                    res,
+                    "tag",
+                    "--sign",
+                    "--annotate",
+                    "--message",
+                    tag_message,
+                    tag_name,
                 )
         if "push_commit" in self.operations and "push_tag" in self.operations:
             if self.atomic_push:


### PR DESCRIPTION
# Add sign support for git

fixes https://github.com/your-tools/tbump/issues/133

## Solution
Same solution as the actual optional argument `atomic_push`.

## Tests
`poetry run pytest` passes

No new tests were added.