### PR TITLE
fix: relative config path error fix

### DIFF
--- a/tbump/config.py
+++ b/tbump/config.py
@@ -53,7 +53,7 @@ class ConfigFileUpdater(Action, metaclass=abc.ABCMeta):
 
     @property
     def relative_path(self) -> Path:
-        return self.path.relative_to(self.project_path)
+        return self.project_path / self.path
 
     def print_self(self) -> None:
         from tbump.cli import print_diff


### PR DESCRIPTION
fixes #168

It works with relative path

```
(tbump-py3.12) ➜  tbump git:(main) ✗ tbump --config ./../tbump/tbump.toml 0.10.1 --only-patch
:: Bumping from 6.11.0 to 0.10.1
/home/slash/CODE/github.com/slashformotion/tbump
../tbump/tbump.toml
/home/slash/CODE/github.com/slashformotion/tbump/../tbump/tbump.toml
=> Would update current version in /home/slash/CODE/github.com/slashformotion/tbump/../tbump/tbump.toml
/home/slash/CODE/github.com/slashformotion/tbump
../tbump/tbump.toml
/home/slash/CODE/github.com/slashformotion/tbump/../tbump/tbump.toml
- /home/slash/CODE/github.com/slashformotion/tbump/../tbump/tbump.toml:6 current = "6.11.0"
+ /home/slash/CODE/github.com/slashformotion/tbump/../tbump/tbump.toml:6 current = "0.10.1"
=> Would patch these files
- pyproject.toml:6 version = "6.11.0"
+ pyproject.toml:6 version = "0.10.1"
- tbump/cli.py:21 TBUMP_VERSION = "6.11.0"
+ tbump/cli.py:21 TBUMP_VERSION = "0.10.1"
:: Looking good? (y/N)
> n
Error: Canceled by user
```