### PR TITLE
 Output messages are sometimes misleading #112 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 .mypy_cache/
 
 .vscode
+.idea

--- a/tbump.toml
+++ b/tbump.toml
@@ -9,6 +9,9 @@ regex = '''
   (?P<minor>\d+)
   \.
   (?P<patch>\d+)
+  (\-
+    (?P<extra>.+)
+  )?
   '''
 
 
@@ -24,6 +27,7 @@ search = 'version = "{current_version}"'
 
 [[file]]
 src = "tbump/cli.py"
+version_template = "{major}.{minor}.{patch}"
 
 [[before_commit]]
 name = "Run CI"

--- a/tbump.toml
+++ b/tbump.toml
@@ -9,9 +9,6 @@ regex = '''
   (?P<minor>\d+)
   \.
   (?P<patch>\d+)
-  (\-
-    (?P<extra>.+)
-  )?
   '''
 
 
@@ -27,7 +24,6 @@ search = 'version = "{current_version}"'
 
 [[file]]
 src = "tbump/cli.py"
-version_template = "{major}.{minor}.{patch}"
 
 [[before_commit]]
 name = "Run CI"

--- a/tbump/file_bumper.py
+++ b/tbump/file_bumper.py
@@ -224,6 +224,8 @@ class FileBumper:
         change_requests = []
         for file in self.files:
             change_request = self.compute_change_request_for_file(file)
+            if change_request.old_string == change_request.new_string:
+                continue
             change_requests.append(change_request)
         return change_requests
 


### PR DESCRIPTION
# Don't run changes if nothing to change

fixes https://github.com/your-tools/tbump/issues/112

# Solution

Check if `old_string == new_string` for `ChangeRequest` before adding to the change requests.

# Tests

With the following template:

```
[version]
current = "6.11.0"
regex = '''
  (?P<major>\d+)
  \.
  (?P<minor>\d+)
  \.
  (?P<patch>\d+)
  (\-
    (?P<extra>.+)
  )?
  '''

...

[[file]]
src = "tbump/cli.py"
version_template = "{major}.{minor}.{patch}"
```

run the command `python -m tbump 6.11.0-1 --dry`

## Previous output

```
:: Bumping from 6.11.0 to 6.11.0-1
=> Would update current version in tbump.toml
- tbump.toml:6 current = "6.11.0"
+ tbump.toml:6 current = "6.11.0-1"
=> Would patch these files
- pyproject.toml:6 version = "6.11.0"
+ pyproject.toml:6 version = "6.11.0-1"
- tbump/cli.py:21 TBUMP_VERSION = "6.11.0"
+ tbump/cli.py:21 TBUMP_VERSION = "6.11.0"
=> Would run these hooks before commit
* (1/2) $ poetry run invoke lint && poetry run pytest
* (2/2) $ grep -q 6.11.0-1 Changelog.rst
=> Would run these git commands
$ git add --update
$ git commit --message Bump to 6.11.0-1
$ git tag --annotate --message v6.11.0-1 v6.11.0-1
$ git push --atomic   v6.11.0-1
=> Would run these hooks after push
* (1/1) $ poetry publish --build
```

## New output

```
:: Bumping from 6.11.0 to 6.11.0-1
=> Would update current version in tbump.toml
- tbump.toml:6 current = "6.11.0"
+ tbump.toml:6 current = "6.11.0-1"
=> Would patch these files
- pyproject.toml:6 version = "6.11.0"
+ pyproject.toml:6 version = "6.11.0-1"
=> Would run these hooks before commit
* (1/2) $ poetry run invoke lint && poetry run pytest
* (2/2) $ grep -q 6.11.0-1 Changelog.rst
=> Would run these git commands
$ git add --update
$ git commit --message Bump to 6.11.0-1
$ git tag --annotate --message v6.11.0-1 v6.11.0-1
$ git push --atomic   v6.11.0-1
=> Would run these hooks after push
* (1/1) $ poetry publish --build
```