### PR TITLE
fix: add proper encoding parsing for when working with Windows files

### DIFF
--- a/tbump/file_bumper.py
+++ b/tbump/file_bumper.py
@@ -202,7 +202,7 @@ class FileBumper:
         for file_path_str in glob.glob(str(file_path_glob), recursive=True):
             file_path = Path(file_path_str)
             expanded_src = file_path.relative_to(self.working_path)
-            old_lines = file_path.read_text().splitlines(keepends=False)
+            old_lines = file_path.read_text(encoding="utf8").splitlines(keepends=False)
 
             for i, old_line in enumerate(old_lines):
                 if should_replace(old_line, old_string, search):


### PR DESCRIPTION
On Windows 10, when trying to use tbump to push tags in my environment, I was getting the following error:

<details>
<summary>Error code snippet</summary>

(my-test-project) PS C:\Users\Dan\PycharmProjects\my-test-project> tbump 0.0.1.dev10
:: Bumping from 0.0.1.dev9 to 0.0.1.dev10
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\Dan\PycharmProjects\my-test-project\.venv\Scripts\tbump.exe\__main__.py", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "C:\Users\Dan\PycharmProjects\my-test-project\.venv\Lib\site-packages\tbump\cli.py", line 296, in main
    run(args)
    ~~~^^^^^^
  File "C:\Users\Dan\PycharmProjects\my-test-project\.venv\Lib\site-packages\tbump\cli.py", line 184, in run
    run_bump(arguments, working_path, arguments.tag_message)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Dan\PycharmProjects\my-test-project\.venv\Lib\site-packages\tbump\cli.py", line 208, in run_bump
    bump(bump_options, _construct_operations(arguments))
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Dan\PycharmProjects\my-test-project\.venv\Lib\site-packages\tbump\cli.py", line 250, in bump
    executor = Executor(new_version, file_bumper, config_file)
  File "C:\Users\Dan\PycharmProjects\my-test-project\.venv\Lib\site-packages\tbump\executor.py", line 64, in __init__
    file_bumper.get_patches(new_version),
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "C:\Users\Dan\PycharmProjects\my-test-project\.venv\Lib\site-packages\tbump\file_bumper.py", line 187, in get_patches
    patches_for_request = self.compute_patches_for_change_request(
        change_request
    )
  File "C:\Users\Dan\PycharmProjects\my-test-project\.venv\Lib\site-packages\tbump\file_bumper.py", line 205, in compute_patches_for_change_request
    old_lines = file_path.read_text().splitlines(keepends=False)
                ~~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\Dan\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\pathlib\_local.py", line 546, in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Dan\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\pathlib\_abc.py", line 633, in read_text
    return f.read()
           ~~~~~~^^
  File "C:\Users\Dan\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\encodings\cp1251.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 4611: character maps to <undefined>


</details>

The same project works fine in Linux. Since it was pointing to the pathlib's read_text, which allows for explicit encoding setup, I tried to set the encoding explicitly, which allowed tbump to work without issue. Haven't tested this thoroughly, but this doesn't seem like too much of a change. Would be glad to fix anything else related to this if required.